### PR TITLE
use the current working directory for scripts root

### DIFF
--- a/src/providers/keys.ts
+++ b/src/providers/keys.ts
@@ -2,7 +2,7 @@ import { readFile } from 'fs/promises'
 import { homedir } from 'os'
 import path from 'path'
 
-const SCRIPTS_ROOT = path.join(homedir(), 'dev', 'efritz', 'aidev')
+const SCRIPTS_ROOT = path.join(process.cwd())
 
 export async function getKey(name: string): Promise<string> {
     return (await readFile(path.join(SCRIPTS_ROOT, 'keys', `${name}.key`), 'utf8')).trim()


### PR DESCRIPTION
use the current directory of the process instead of the hard coded path