### PR TITLE
Update where we look for provider keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 dist
 node_modules
-*.key

--- a/README.md
+++ b/README.md
@@ -6,14 +6,39 @@ This project provides a personalized AI assistant that can be used through a CLI
 
 Before running the AI assistant, ensure that:
 
-1. The `code` command is available on your PATH. This is typically installed with Visual Studio Code.
-2. For the VSCode extension to work properly, the CLI run instructions must be aliased to 'ai'. Add this alias to your shell configuration file:
+1. API keys are configured for your chosen LLM provider(s). Store your API keys in `~/.config/aidev/keys/` following this convention:
 
-```bash
-alias ai='node /path/to/aidev/dist/cli.js'
-```
+   ```bash
+   # Create the config directory
+   mkdir -p ~/.config/aidev/keys
 
-Replace `/path/to/aidev` with the path to this project.
+   # Store your API keys (one per file)
+   echo 'your-api-key' > ~/.config/aidev/keys/openai.key
+   chmod 600 ~/.config/aidev/keys/*.key  # Secure the files
+   ```
+
+   By default, keys are stored in `~/.config/aidev/keys`, but you can override this location by setting the `AIDEV_KEY_DIR` environment variable:
+
+   ```bash
+   export AIDEV_KEY_DIR="/custom/path/to/keys/dir"
+   ```
+
+   Key files for each provider will be expected upon use:
+
+   - `anthropic.key`
+   - `openai.key`
+   - `google.key`
+   - `groq.key`
+
+2. The `code` command is available on your PATH. This is typically installed with Visual Studio Code.
+
+3. For the VSCode extension to work properly, the CLI run instructions must be aliased to 'ai'. Add this alias to your shell configuration file:
+
+   ```bash
+   alias ai='node /path/to/aidev/dist/cli.js'
+   ```
+
+   Replace `/path/to/aidev` with the path to this project.
 
 ## Installation
 

--- a/src/providers/keys.ts
+++ b/src/providers/keys.ts
@@ -2,8 +2,18 @@ import { readFile } from 'fs/promises'
 import { homedir } from 'os'
 import path from 'path'
 
-const SCRIPTS_ROOT = path.join(homedir(), 'dev', 'efritz', 'aidev')
-
 export async function getKey(name: string): Promise<string> {
-    return (await readFile(path.join(SCRIPTS_ROOT, 'keys', `${name}.key`), 'utf8')).trim()
+    return (await readFile(keyPath(name), 'utf8')).trim()
+}
+
+function keyPath(name: string): string {
+    return path.join(keyDir(), `${name}.key`)
+}
+
+function keyDir(): string {
+    return process.env.AIDEV_KEY_DIR || path.join(xdgConfigHome(), 'aidev', 'keys')
+}
+
+function xdgConfigHome(): string {
+    return process.env.XDG_CONFIG_HOME || path.join(homedir(), '.config')
 }


### PR DESCRIPTION
Allow keys to be loaded from a non-`efritz` home directory. The user may either:

- Define `AIDEV_KEY_DIR` and put your keys there
- Shove your keys into `~/.config/aidev/keys` (the default place to look)
- If you're neurotic and have defined `XDG_CONFIG_HOME`, then look in `${XDG_CONFIG_HOME}/aidev/keys` instead.