### PR TITLE
provider: associate models with their provider

### DIFF
--- a/src/chat/commands/commands.ts
+++ b/src/chat/commands/commands.ts
@@ -9,7 +9,7 @@ import { unstashCommand } from './context/unstash'
 import { writeCommand } from './context/write'
 import { exitCommand } from './control/exit'
 import { helpCommand } from './control/help'
-import { modelCommand } from './control/model'
+import { modelCommand, modelsCommand } from './control/model'
 import { branchCommand } from './conversation/branch'
 import { clearCommand } from './conversation/clear'
 import { continueCommand } from './conversation/continue'
@@ -29,6 +29,7 @@ export const commands: CommandDescription[] = [
     helpCommand,
     exitCommand,
     modelCommand,
+    modelsCommand,
     promptCommand,
     continueCommand,
     saveCommand,

--- a/src/chat/commands/control/model.ts
+++ b/src/chat/commands/control/model.ts
@@ -1,6 +1,6 @@
 import { CompleterResult } from 'readline'
 import chalk from 'chalk'
-import { modelNames } from '../../../providers/providers'
+import { formattedModels, modelNames } from '../../../providers/providers'
 import { ChatContext, swapProvider } from '../../context'
 import { CommandDescription } from '../command'
 
@@ -25,7 +25,7 @@ async function handleModel(context: ChatContext, args: string) {
         console.log(chalk.red.bold(`Invalid model name: ${modelName}`))
         console.log()
         console.log('Valid models:')
-        console.log(modelNames.join('\n'))
+        console.log(formattedModels)
         console.log()
         return
     }
@@ -43,3 +43,17 @@ async function handleModel(context: ChatContext, args: string) {
 async function completeModel(context: ChatContext, args: string): Promise<CompleterResult> {
     return [modelNames.filter(name => name.startsWith(args)), args]
 }
+
+export const modelsCommand: CommandDescription = {
+    prefix: ':models',
+    description: 'List available models',
+    handler:     handleModels,
+}
+
+async function handleModels(context: ChatContext, args: string) { 
+        console.log()
+        console.log(formattedModels)
+        console.log()
+        return
+}
+

--- a/src/providers/anthropic/provider.ts
+++ b/src/providers/anthropic/provider.ts
@@ -7,6 +7,8 @@ import { Model, Provider, ProviderOptions, ProviderSpec } from '../provider'
 import { createConversation } from './conversation'
 import { createStreamReducer } from './reducer'
 
+export const providerName = 'Anthropic'
+
 const models: Model[] = [
     {
         name: 'haiku',
@@ -27,6 +29,7 @@ const models: Model[] = [
 ]
 
 export const provider: ProviderSpec = {
+    name: providerName,
     models,
     factory: createAnthropicProvider,
 }

--- a/src/providers/google/provider.ts
+++ b/src/providers/google/provider.ts
@@ -11,6 +11,8 @@ import { Model, Provider, ProviderOptions, ProviderSpec } from '../provider'
 import { createConversation } from './conversation'
 import { createStreamReducer } from './reducer'
 
+export const providerName = 'Google'
+
 const models: Model[] = [
     {
         name: 'gemini',
@@ -19,6 +21,7 @@ const models: Model[] = [
 ]
 
 export const provider: ProviderSpec = {
+    name: providerName,
     models,
     factory: createGoogleProvider,
 }

--- a/src/providers/groq/provider.ts
+++ b/src/providers/groq/provider.ts
@@ -8,6 +8,8 @@ import { Model, Provider, ProviderOptions, ProviderSpec } from '../provider'
 import { createConversation } from './conversation'
 import { createStreamReducer } from './reducer'
 
+export const providerName = 'Groq'
+
 const models: Model[] = [
     {
         name: 'llama3-70b',
@@ -16,6 +18,7 @@ const models: Model[] = [
 ]
 
 export const provider: ProviderSpec = {
+    name: providerName,
     models,
     factory: createGroqProvider,
 }

--- a/src/providers/ollama/provider.ts
+++ b/src/providers/ollama/provider.ts
@@ -5,6 +5,8 @@ import { Model, Provider, ProviderOptions, ProviderSpec } from '../provider'
 import { createConversation } from './conversation'
 import { createStreamReducer } from './reducer'
 
+export const providerName = 'Ollama'
+
 const models: Model[] = [
     {
         name: 'llama3',
@@ -17,6 +19,7 @@ const models: Model[] = [
 ]
 
 export const provider: ProviderSpec = {
+    name: providerName,
     models,
     factory: createOllamaProvider,
 }

--- a/src/providers/openai/provider.ts
+++ b/src/providers/openai/provider.ts
@@ -7,6 +7,8 @@ import { Model, Provider, ProviderOptions, ProviderSpec } from '../provider'
 import { createConversation } from './conversation'
 import { createStreamReducer } from './reducer'
 
+export const providerName = 'Openai'
+
 const models: Model[] = [
     {
         name: 'o1-preview',
@@ -37,6 +39,7 @@ const models: Model[] = [
 ]
 
 export const provider: ProviderSpec = {
+    name: providerName,
     models,
     factory: createOpenAIProvider,
 }

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -20,6 +20,7 @@ export type Provider = {
 }
 
 export type ProviderSpec = {
+    name: string
     models: Model[]
     factory: ProviderFactory
 }

--- a/src/providers/providers.ts
+++ b/src/providers/providers.ts
@@ -4,10 +4,23 @@ import { provider as googleProvider } from './google/provider'
 import { provider as groqProvider } from './groq/provider'
 import { provider as ollamaProvider } from './ollama/provider'
 import { provider as openAIProvider } from './openai/provider'
-import { Provider, ProviderSpec } from './provider'
+import { Provider, ProviderSpec, Model } from './provider'
 
 const providers: ProviderSpec[] = [anthropicProvider, openAIProvider, googleProvider, groqProvider, ollamaProvider]
-export const modelNames = providers.flatMap(({ models }) => models.map(({ name }) => name)).sort()
+
+export const providerModels = providers.reduce((acc, provider) => {
+    acc[provider.name] = provider.models
+    return acc
+}, {} as Record<string, Model[]>)
+
+export const modelNames = Object.values(providerModels).flat().map(model => model.name).sort()
+
+export const formattedModels = Object.entries(providerModels)
+            .map(([name, models]) => {
+                const modelNames = models.map(model => model.name).join(', ')
+                return `- ${name}: ${modelNames}`
+            })
+            .join('\n')
 
 export function createProvider(contextState: ContextState, modelName: string, system: string): Promise<Provider> {
     const pairs = providers.flatMap(({ factory, models }) => models.map(model => ({ factory, model })))


### PR DESCRIPTION
Adds in a `:models` command that enumerates all models. Also updates the provider code to include the provider name (e.g. `google`, `anthropic`, etc) so that it's obvious which models come from where to set keys or configuration. Notably, it was unclear which models were `ollama` before. Maintained backwards compatibility with the flat map though so I didn't have to update that code.

My TypeScript is passable at best, feel free to throw this away if you don't like it.

## Examples
```
[main] $ :models

- Anthropic: haiku, sonnet, opus
- Openai: o1-preview, o1-mini, gpt-4o, gpt-4
- Google: gemini
- Groq: llama3-70b
- Ollama: llama3, qwen
```

```
[main] $ :model kalan
Invalid model name: kalan

Valid models:
- Anthropic: haiku, sonnet, opus
- Openai: o1-preview, o1-mini, gpt-4o, gpt-4
- Google: gemini
- Groq: llama3-70b
- Ollama: llama3, qwen
```

Tab completions:
```
[main] $ :model
gemini      gpt-4       gpt-4o      haiku       llama3      llama3-70b  o1-mini     o1-preview  opus        qwen        sonnet
```
