### PR TITLE
hack: allow ability to connect to remove ollama server

### DIFF
--- a/src/embeddings/client/ollama.ts
+++ b/src/embeddings/client/ollama.ts
@@ -1,7 +1,10 @@
-import ollama from 'ollama'
+import ollama, { Ollama } from 'ollama'
 import { Preferences } from '../../providers/preferences'
 import { Limiter, wrapPromise } from '../../util/ratelimits/limiter'
 import { Client, ClientFactory, ClientSpec, registerModelLimits } from './client'
+
+// Create an Ollama client with a configurable host
+const ollamaClient = new Ollama({ host: process.env.OLLAMA_HOST  ||'http://localhost:11434' })
 
 export async function createOllamaClientSpec(preferences: Preferences, limiter: Limiter): Promise<ClientSpec> {
     const providerName = 'Ollama'
@@ -29,7 +32,7 @@ function createOllamaClient(providerName: string, limiter: Limiter): ClientFacto
                 modelName,
                 async (input: string[]) =>
                     (
-                        await ollama.embed({
+                        await ollamaClient.embed({
                             model,
                             input,
                         })

--- a/src/providers/ollama/provider.ts
+++ b/src/providers/ollama/provider.ts
@@ -1,4 +1,4 @@
-import ollama, { ChatResponse, Message, Tool } from 'ollama'
+import ollama, { Ollama, ChatResponse, Message, Tool } from 'ollama'
 import { tools as toolDefinitions } from '../../tools/tools'
 import { abortableIterable, toIterable } from '../../util/iterable/iterable'
 import { Limiter, wrapAsyncIterable } from '../../util/ratelimits/limiter'
@@ -7,6 +7,9 @@ import { Preferences } from '../preferences'
 import { Provider, ProviderFactory, ProviderOptions, ProviderSpec, registerModelLimits } from '../provider'
 import { createConversation } from './conversation'
 import { createStreamReducer } from './reducer'
+
+// Create an Ollama client with a configurable host
+const ollamaClient = new Ollama({ host: process.env.OLLAMA_HOST  ||'http://localhost:11434' })
 
 export async function createOllamaProviderSpec(preferences: Preferences, limiter: Limiter): Promise<ProviderSpec> {
     const providerName = 'Ollama'
@@ -78,7 +81,7 @@ function createStreamFactory({
     return wrapAsyncIterable(limiter, model, async (messages: Message[], signal?: AbortSignal) => {
         // https://github.com/ollama/ollama-js/issues/123
         const iterable = toIterable(() =>
-            ollama.chat({
+            ollamaClient.chat({
                 model,
                 messages,
                 options: {


### PR DESCRIPTION
This code is trash and is useful for conceptual purposes only.

`OLLAMA_SERVER` is the env var that the `ollama` CLI respects. Setting it to `0.0.0.0:port` on the host and then whatever the server IP is on the client allows `aidev` to talk to a remote Ollama server.

Been using this to try and get `aidev` running on Linux (WSL) to leverage my GPU (Windows).