### PR TITLE
shell: configurable shell command

### DIFF
--- a/configs/preferences.default.yaml
+++ b/configs/preferences.default.yaml
@@ -3,6 +3,7 @@ reprompterModel: haiku
 embeddingsModel: mxbai-embed-large
 summarizerModel: gpt-4o-mini
 webTranslatorModel: gpt-4o-mini
+shellCommand: "zsh -c"
 
 providers:
     Anthropic: { include: ./models/chat/anthropic.yaml }

--- a/src/providers/preferences.ts
+++ b/src/providers/preferences.ts
@@ -50,7 +50,8 @@ const PreferencesSchema = z.object({
         z.enum(embeddingsProviderSpecFactories.map(f => f.name) as [string, ...string[]]),
         z.array(EmbeddingModelSchema),
     ),
-})
+    shellCommand: z.string(),
+});
 
 export type ChatModel = z.infer<typeof ChatModelSchema>
 export type EmbeddingsModel = z.infer<typeof EmbeddingModelSchema>

--- a/src/util/shell/exec.ts
+++ b/src/util/shell/exec.ts
@@ -46,8 +46,9 @@ async function runCommand(context: ChatContext, command: string, update: Updater
                     update(output)
                 }
             }
-
-            const cmd = spawn('zsh', ['-c', command])
+            const shellCommand = context.preferences.shellCommand || "zsh -c";
+            const [shell, shellFlag] = shellCommand.split(" ", 2);
+            const cmd = spawn(shell, [shellFlag, command]);
             cmd.stdout.on('data', data => aggregate('stdout', data.toString()))
             cmd.stderr.on('data', data => aggregate('stderr', data.toString()))
 


### PR DESCRIPTION
Support a simple preference change that allows you to specify the command that should be used by the agent to execute shell commands.

`fish` uses the same `-c` syntax but I have the pref to be the full command in case it's something different, but the pref could easily be reduced to just `shell: fish` and have it guess the `-c` like
```typescript
            const shell = context.preferences.shellCommand || "zsh";
            const cmd = spawn(shell, ["-c", command]);
```

## Before (`main`)
```
[main] $ What branch am i on?
✔ Generated response.

I'll help you check which git branch you're currently on using the shell command.

> git branch --show-current
Execute this command [y/N/e/?]? y
✖ Command failed.

error: Executable not found in $PATH: "zsh"

✔ Assistant will continue...

✔ Generated response.

I apologize, but it seems I'm unable to execute the git command directly. Let me try a different approach to show your current branch:

```
## After (this branch)
```
[main] $ What git branch am I on?
✔ Generated response.

I'll help you determine which git branch you're on using the shell_execute tool to run a git command.

> git branch --show-current
Execute this command [y/N/e/?]? y
✔ Command succeeded.

main

✔ Assistant is done.
```
