### PR TITLE
Sink promise for loaded context files and directories

### DIFF
--- a/scripts/convert-transcript.ts
+++ b/scripts/convert-transcript.ts
@@ -45,8 +45,12 @@ async function convertHistoryToProviderMessages(inFilename: string, providerName
     }
 
     const contextState = await createContextState()
-    contextState.setFiles(new Map(Object.entries(contextFiles)))
-    contextState.setDirectories(new Map(Object.entries(contextDirectories)))
+    contextFiles.forEach(({ path, inclusionReasons }) =>
+        inclusionReasons.forEach(reason => contextState.addFiles(path, reason)),
+    )
+    contextDirectories.forEach(({ path, inclusionReasons }) =>
+        inclusionReasons.forEach(reason => contextState.addDirectories(path, reason)),
+    )
 
     const preferences = await getPreferences()
     const system = await buildSystemPrompt(preferences)

--- a/scripts/convert-transcript.ts
+++ b/scripts/convert-transcript.ts
@@ -53,7 +53,7 @@ async function convertHistoryToProviderMessages(inFilename: string, providerName
 
     const conversation = createConversation(contextState, system)
     conversation.setMessages(messages)
-    return JSON.stringify(conversation.providerMessages(), null, '\t')
+    return JSON.stringify(await conversation.providerMessages(), null, '\t')
 }
 
 main()

--- a/src/chat/commands/load.ts
+++ b/src/chat/commands/load.ts
@@ -33,7 +33,7 @@ async function handleLoadPatterns(context: ChatContext, patterns: string[]): Pro
         return
     }
 
-    await context.contextStateManager.addFiles(paths, { type: 'explicit' })
+    context.contextStateManager.addFiles(paths, { type: 'explicit' })
 
     paths.sort()
     const message = paths.map(path => `${chalk.dim('ℹ')} Added "${chalk.red(path)}" into context.`).join('\n')

--- a/src/chat/commands/loaddir.ts
+++ b/src/chat/commands/loaddir.ts
@@ -33,7 +33,7 @@ async function handleLoaddirPatterns(context: ChatContext, patterns: string[]): 
         return
     }
 
-    await context.contextStateManager.addDirectories(paths, { type: 'explicit' })
+    context.contextStateManager.addDirectories(paths, { type: 'explicit' })
 
     paths.sort()
     const message = paths.map(path => `${chalk.dim('ℹ')} Added "${chalk.red(path)}" into context.`).join('\n')

--- a/src/chat/commands/save.ts
+++ b/src/chat/commands/save.ts
@@ -22,8 +22,18 @@ async function handleSave(context: ChatContext, args: string) {
     const contents: SaveFilePayload = {
         model: context.provider.modelName,
         messages: context.provider.conversationManager.messages(),
-        contextFiles: mapToRecord(context.contextStateManager.files()),
-        contextDirectories: mapToRecord(context.contextStateManager.directories()),
+        contextFiles: [
+            ...context.contextStateManager
+                .files()
+                .values()
+                .map(({ content: _, ...v }) => v),
+        ],
+        contextDirectories: [
+            ...context.contextStateManager
+                .directories()
+                .values()
+                .map(({ entries: _, ...v }) => v),
+        ],
     }
 
     const filename = `chat-${Math.floor(Date.now() / 1000)}.json`
@@ -31,18 +41,11 @@ async function handleSave(context: ChatContext, args: string) {
     console.log(`Chat history saved to ${filename}\n`)
 }
 
-function mapToRecord<K extends string | number | symbol, V>(map: Map<K, V>): Record<K, V> {
-    return Array.from(map).reduce((obj: any, [key, value]) => {
-        obj[key] = value
-        return obj
-    }, {})
-}
-
 export type SaveFilePayload = {
     model: string
     messages: Message[]
-    contextFiles: Record<string, ContextFile>
-    contextDirectories: Record<string, ContextDirectory>
+    contextFiles: Omit<ContextFile, 'content'>[]
+    contextDirectories: Omit<ContextDirectory, 'entries'>[]
 }
 
 function replacer(_key: string, value: any): any {

--- a/src/chat/commands/save_provider.ts
+++ b/src/chat/commands/save_provider.ts
@@ -16,7 +16,7 @@ async function handleSaveProvider(context: ChatContext, args: string) {
         return
     }
 
-    const contents = context.provider.providerMessages()
+    const contents = await context.provider.providerMessages()
 
     const filename = `provider-messages-${Math.floor(Date.now() / 1000)}.json`
     await writeFile(filename, JSON.stringify(contents, null, '\t'))

--- a/src/chat/history.ts
+++ b/src/chat/history.ts
@@ -14,8 +14,12 @@ export async function loadHistory(context: ChatContext, historyFilename: string)
 
     await swapProvider(context, model)
     context.provider.conversationManager.setMessages(messages)
-    context.contextStateManager.setFiles(new Map(Object.entries(contextFiles)))
-    context.contextStateManager.setDirectories(new Map(Object.entries(contextDirectories)))
+    contextFiles.forEach(({ path, inclusionReasons }) =>
+        inclusionReasons.forEach(reason => context.contextStateManager.addFiles(path, reason)),
+    )
+    contextDirectories.forEach(({ path, inclusionReasons }) =>
+        inclusionReasons.forEach(reason => context.contextStateManager.addDirectories(path, reason)),
+    )
 
     replayMessages(context)
 }

--- a/src/mcp/client/client.ts
+++ b/src/mcp/client/client.ts
@@ -36,9 +36,9 @@ function createUpdateEditorContextHandler(context: ChatContext, client: Client):
     return async () => {
         const { resources } = await client.listResources()
 
-        await context.contextStateManager.addFiles([...loaded], { type: 'editor', currentlyOpen: false })
+        context.contextStateManager.addFiles([...loaded], { type: 'editor', currentlyOpen: false })
         loaded = new Set(resources.map(({ name }) => name))
-        await context.contextStateManager.addFiles([...loaded], { type: 'editor', currentlyOpen: true })
+        context.contextStateManager.addFiles([...loaded], { type: 'editor', currentlyOpen: true })
 
         context.events.emit('open-files-changed')
     }

--- a/src/providers/chat_provider.ts
+++ b/src/providers/chat_provider.ts
@@ -19,7 +19,7 @@ export type ChatProvider = {
     modelName: string
     system: string
     conversationManager: ConversationManager
-    providerMessages: () => any[]
+    providerMessages: () => Promise<any[]>
     prompt: (progress?: ProgressFunction, signal?: AbortSignal) => Promise<Response>
 }
 

--- a/src/providers/factory.ts
+++ b/src/providers/factory.ts
@@ -34,7 +34,7 @@ export function createChatProvider<T, M>({
         providerMessages,
         prompt: async (progress?: ProgressFunction, signal?: AbortSignal) => {
             const response = await reduceStream({
-                iterator: await createStream(providerMessages(), signal),
+                iterator: await createStream(await providerMessages(), signal),
                 reducer: createStreamReducer(),
                 progress,
             })

--- a/src/tools/fs/edit_file.ts
+++ b/src/tools/fs/edit_file.ts
@@ -73,7 +73,7 @@ export const editFile: Tool<EditResult> = {
         const originalContents = await safeReadFile(path)
         const contents = applyEdits(originalContents, edits, path)
         const result = await executeWriteFile({ ...context, path, contents, originalContents })
-        await context.contextStateManager.addFiles(path, { type: 'tool_use', toolUseClass: 'write', toolUseId })
+        context.contextStateManager.addFiles(path, { type: 'tool_use', toolUseClass: 'write', toolUseId })
         return editExecutionResultFromWriteResult(result)
     },
     serialize: ({ result, error, canceled }: ToolResult<EditResult>) => ({

--- a/src/tools/fs/read_directories.ts
+++ b/src/tools/fs/read_directories.ts
@@ -45,7 +45,7 @@ export const readDirectories: Tool<string[]> = {
         const { paths: patterns } = args as { paths: string[] }
         const directoryPaths = (await filterIgnoredPaths(await expandDirectoryPatterns(patterns))).sort()
 
-        await context.contextStateManager.addDirectories(directoryPaths, {
+        context.contextStateManager.addDirectories(directoryPaths, {
             type: 'tool_use',
             toolUseClass: 'read',
             toolUseId,

--- a/src/tools/fs/read_files.ts
+++ b/src/tools/fs/read_files.ts
@@ -43,7 +43,7 @@ export const readFiles: Tool<string[]> = {
         const { paths: patterns } = args as { paths: string[] }
         const filePaths = (await filterIgnoredPaths(await expandFilePatterns(patterns))).sort()
 
-        await context.contextStateManager.addFiles(filePaths, { type: 'tool_use', toolUseClass: 'read', toolUseId })
+        context.contextStateManager.addFiles(filePaths, { type: 'tool_use', toolUseClass: 'read', toolUseId })
 
         console.log(
             filePaths.map(path => `${chalk.dim('ℹ')} Added file "${chalk.red(path)}" into context.`).join('\n'),

--- a/src/tools/fs/write_file.ts
+++ b/src/tools/fs/write_file.ts
@@ -52,7 +52,7 @@ export const writeFile: Tool<WriteResult> = {
         const { path, contents } = args as { path: string; contents: string }
         const originalContents = await safeReadFile(path)
         const result = await executeWriteFile({ ...context, path, contents, originalContents })
-        await context.contextStateManager.addFiles(path, { type: 'tool_use', toolUseClass: 'write', toolUseId })
+        context.contextStateManager.addFiles(path, { type: 'tool_use', toolUseClass: 'write', toolUseId })
         return writeExecutionResultFromWriteResult(result)
     },
     serialize: ({ result, error, canceled }: ToolResult<WriteResult>) => ({

--- a/src/util/fs/write.ts
+++ b/src/util/fs/write.ts
@@ -58,7 +58,7 @@ export async function executeWriteFile({
         await _writeFile(path, editedContents)
 
         if (fromStash) {
-            await contextStateManager.addFiles(path, {
+            contextStateManager.addFiles(path, {
                 type: 'stash_applied',
                 metaMessageId: provider.conversationManager.applyStashedFile(path, editedContents, originalContents),
             })


### PR DESCRIPTION
Instead of having a background promise that may or may not be resolved by the time provider messages are constructed, just stash a promise on change to the context file and wait for it to settle at the time it's needed.