### PR TITLE
Remove tool use class

### DIFF
--- a/src/context/reason.ts
+++ b/src/context/reason.ts
@@ -1,17 +1,13 @@
 export type InclusionReason =
     | { type: 'explicit' }
-    | { type: 'tool_use'; toolUseClass: 'read' | 'write'; toolUseId: string }
+    | { type: 'tool_use'; toolUseId: string }
     | { type: 'editor'; currentlyOpen: boolean }
     | { type: 'stash_applied'; metaMessageId: string }
 
 export function updateInclusionReasons(reasons: InclusionReason[], reason: InclusionReason) {
     if (
         (reason.type === 'explicit' && reasons.some(r => r.type === 'explicit')) ||
-        (reason.type === 'tool_use' &&
-            reasons.some(
-                r =>
-                    r.type === 'tool_use' && r.toolUseClass === reason.toolUseClass && r.toolUseId === reason.toolUseId,
-            ))
+        (reason.type === 'tool_use' && reasons.some(r => r.type === 'tool_use' && r.toolUseId === reason.toolUseId))
     ) {
         // Already exists
         return

--- a/src/conversation/conversation.ts
+++ b/src/conversation/conversation.ts
@@ -215,11 +215,7 @@ function shouldInclude(reasons: InclusionReason[], visibleToolUses: string[]): b
                 return true
 
             case 'tool_use':
-                // If we ONLY write to a file we don't need to include it. We only want to include
-                // a file if it's explicitly read by a tool. We keep the 'write' tool use class to
-                // ensure that we always include the file contents after the last modification so
-                // the assistant doesn't get confused about the current state of the contents.
-                if (reason.toolUseClass === 'read' && visibleToolUses.includes(reason.toolUseId)) {
+                if (visibleToolUses.includes(reason.toolUseId)) {
                     return true
                 }
 

--- a/src/tools/fs/edit_file.ts
+++ b/src/tools/fs/edit_file.ts
@@ -73,7 +73,7 @@ export const editFile: Tool<EditResult> = {
         const originalContents = await safeReadFile(path)
         const contents = applyEdits(originalContents, edits, path)
         const result = await executeWriteFile({ ...context, path, contents, originalContents })
-        context.contextStateManager.addFiles(path, { type: 'tool_use', toolUseClass: 'write', toolUseId })
+        context.contextStateManager.addFiles(path, { type: 'tool_use', toolUseId })
         return editExecutionResultFromWriteResult(result)
     },
     serialize: ({ result, error, canceled }: ToolResult<EditResult>) => ({

--- a/src/tools/fs/read_directories.ts
+++ b/src/tools/fs/read_directories.ts
@@ -45,11 +45,7 @@ export const readDirectories: Tool<string[]> = {
         const { paths: patterns } = args as { paths: string[] }
         const directoryPaths = (await filterIgnoredPaths(await expandDirectoryPatterns(patterns))).sort()
 
-        context.contextStateManager.addDirectories(directoryPaths, {
-            type: 'tool_use',
-            toolUseClass: 'read',
-            toolUseId,
-        })
+        context.contextStateManager.addDirectories(directoryPaths, { type: 'tool_use', toolUseId })
 
         console.log(
             directoryPaths

--- a/src/tools/fs/read_files.ts
+++ b/src/tools/fs/read_files.ts
@@ -43,7 +43,7 @@ export const readFiles: Tool<string[]> = {
         const { paths: patterns } = args as { paths: string[] }
         const filePaths = (await filterIgnoredPaths(await expandFilePatterns(patterns))).sort()
 
-        context.contextStateManager.addFiles(filePaths, { type: 'tool_use', toolUseClass: 'read', toolUseId })
+        context.contextStateManager.addFiles(filePaths, { type: 'tool_use', toolUseId })
 
         console.log(
             filePaths.map(path => `${chalk.dim('ℹ')} Added file "${chalk.red(path)}" into context.`).join('\n'),

--- a/src/tools/fs/write_file.ts
+++ b/src/tools/fs/write_file.ts
@@ -52,7 +52,7 @@ export const writeFile: Tool<WriteResult> = {
         const { path, contents } = args as { path: string; contents: string }
         const originalContents = await safeReadFile(path)
         const result = await executeWriteFile({ ...context, path, contents, originalContents })
-        context.contextStateManager.addFiles(path, { type: 'tool_use', toolUseClass: 'write', toolUseId })
+        context.contextStateManager.addFiles(path, { type: 'tool_use', toolUseId })
         return writeExecutionResultFromWriteResult(result)
     },
     serialize: ({ result, error, canceled }: ToolResult<WriteResult>) => ({


### PR DESCRIPTION
When writing a file, its updated contents should be made available in the context. This is more explicit and should help keep the current state of the filesystem in the context properly with less confusion.